### PR TITLE
Add Heroku error code descriptions to requests

### DIFF
--- a/app/default/props.conf
+++ b/app/default/props.conf
@@ -16,3 +16,6 @@ EXTRACT-heroku_log_format = ^\S+\s(?<component>\S+)\s(?<dyno>\S+)
 
 # For JSON strip header values to enable syntax highlighting.
 EVAL-_raw = replace(_raw, "^.+\s-\s(\{.+\})\s*$", "\1")
+
+# Look up the Heroku error code description, see https://devcenter.heroku.com/articles/error-codes.
+LOOKUP-heroku_error = heroku_error_lookup code OUTPUTNEW desc AS code_desc

--- a/app/default/transforms.conf
+++ b/app/default/transforms.conf
@@ -4,3 +4,6 @@
 REGEX = router\s-\s.+path="\/__(gtg|health)"\s.+status=200
 DEST_KEY = queue
 FORMAT = nullQueue
+
+[heroku_error_lookup]
+filename = heroku_errors.csv

--- a/app/lookups/heroku_errors.csv
+++ b/app/lookups/heroku_errors.csv
@@ -1,0 +1,39 @@
+code,desc
+H10,App crashed
+H11,Backlog too deep
+H12,Request timeout
+H13,Connection closed without response
+H14,No web dynos running
+H15,Idle connection
+H17,Poorly formatted HTTP response
+H18,Server Request Interrupted
+H19,Backend connection timeout
+H20,App boot timeout
+H21,Backend connection refused
+H22,Connection limit reached
+H23,Endpoint misconfigured
+H24,Forced close
+H25,HTTP Restriction
+H26,Request Error
+H27,Client Request Interrupted
+H28,Client Connection Idle
+H31,Misdirected Request
+H80,Maintenance mode
+H81,Blank app
+H82,Free dyno quota exhausted
+H83,Planned Service Degradation
+H99,Platform error
+R10,Boot timeout
+R12,Exit timeout
+R13,Attach error
+R14,Memory quota exceeded
+R15,Memory quota vastly exceeded
+R16,Detached
+R17,Checksum error
+R99,Platform error
+L10,Drain buffer overflow
+L11,Tail buffer overflow
+L12,Local buffer overflow
+L13,Local delivery error
+L14,Certificate validation error
+L15,Tail buffer temporarily unavailable


### PR DESCRIPTION
Enrich any Heroku requests containing an error code by adding a description of the error code.

Based on the list at https://devcenter.heroku.com/articles/error-codes, inspired by the configuration in https://splunkbase.splunk.com/app/1873/#/details.