### PR TITLE
Fix heroku_requests_null_queue transform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ latest: splunk_heroku-latest.tar.gz
 #
 # The tar directory structure must include a base directory named
 # after the app ID in app.conf.
-splunk_heroku-%.tar.gz: $(wildcard app/*.conf)
+splunk_heroku-%.tar.gz: $(wildcard app/default/*.conf) $(wildcard app/lookups/*.csv) $(wildcard app/metadata/*.meta)
 	mkdir -p $(TMPDIR)/splunk_heroku/
 	cp -r app/* $(TMPDIR)/splunk_heroku/
 	tar -C $(TMPDIR) -czf $(TMPDIR)/$@ splunk_heroku/

--- a/app/default/props.conf
+++ b/app/default/props.conf
@@ -16,6 +16,9 @@ SEDCMD-strip_json_prefix = s/^.+\s-\s(\{.+\})\s*$/\1/
 # Set specific source types for non-app Heroku log drain messages, e.g. Heroku router messages.
 TRANSFORMS-source_type = heroku_system_source_type, heroku_requests_source_type, heroku_api_source_type
 
+# Do not index some high volume low value messages.
+TRANSFORMS-heroku_requests_null_queue = heroku_requests_null_queue
+
 [heroku_system]
 category = Structured
 description = Messages about actions taken by the Heroku platform.
@@ -31,9 +34,6 @@ LOOKUP-heroku_code_desc = heroku_error_lookup code OUTPUTNEW desc AS code_desc
 
 # Note: Only extract component as request logs contain a dyno field with a value that aligns with the other Heroku source types. Would always be "router" otherwise.
 EXTRACT-heroku_component = ^\S+\s(?<component>\S+)
-
-# Do not index some high volume low value messages.
-TRANSFORMS-heroku_requests_null_queue = heroku_requests_null_queue
 
 [heroku_api]
 category = Structured

--- a/app/default/transforms.conf
+++ b/app/default/transforms.conf
@@ -1,6 +1,6 @@
 # Drop events for successful __gtg and __health requests, these logs then don't count towards our ingest license usage, index time.
 [heroku_requests_null_queue]
-REGEX = router\s-\s.+path="\/__(gtg|health)"\s.+status=200
+REGEX = router\s-\s.+path="[^"]*\/__(gtg|health)"\s.+status=200
 DEST_KEY = queue
 FORMAT = nullQueue
 


### PR DESCRIPTION
Resolves #23, tested locally.

Promotes the `heroku_requests_null_queue` to apply on the `heroku` source type. On the more specific source types transforms do not seem to work.

Also updates the regex to match for nested paths, e.g. requests to `/api/v1/__health` can now match the `heroku_requests_null_queue` transform.

Quick fix of the Makefile too, `make splunk_heroku-latest.tar.gz` will now run if the source files have been changed.