### PR TITLE
Making regex less explicit for heroku_requests nullqueue

### DIFF
--- a/app/default/transforms.conf
+++ b/app/default/transforms.conf
@@ -1,6 +1,6 @@
-# Drop events for successful __gtg and __health requests, these logs then don't count towards our ingest license usage, index time.
+# Drop events for any double underscore (__) path, these logs then don't count towards our ingest license usage, index time.
 [heroku_requests_null_queue]
-REGEX = router\s-\s.+path="[^"]*\/__(gtg|health)"\s.+status=200
+REGEX = router\s-\s.+path="[^"]*\/__[^\/"]*"\s.+status=200
 DEST_KEY = queue
 FORMAT = nullQueue
 


### PR DESCRIPTION
resolves https://github.com/Financial-Times/splunk-heroku/issues/26
