### PR TITLE
Add null queue transform for canary request messages

### DIFF
--- a/app/default/props.conf
+++ b/app/default/props.conf
@@ -14,10 +14,10 @@ SEDCMD-strip_rfc5424_header = s/^\d+\s<\d{1,3}>\d\s(.+)\shost\s/\1 /
 SEDCMD-strip_json_prefix = s/^.+\s-\s(\{.+\})\s*$/\1/
 
 # Set specific source types for non-app Heroku log drain messages, e.g. Heroku router messages.
-TRANSFORMS-source_type = heroku_system_source_type, heroku_router_source_type, heroku_api_source_type
+TRANSFORMS-source_type = heroku_app_source_type, heroku_system_source_type, heroku_router_source_type, heroku_api_source_type
 
 # Do not index some high volume low value messages.
-TRANSFORMS-heroku_router_null_queue = heroku_router_double_underscore_null_queue
+TRANSFORMS-heroku_router_null_queue = heroku_router_double_underscore_null_queue, heroku_router_canary_null_queue
 
 [heroku:app]
 category = Structured

--- a/app/default/tags.conf
+++ b/app/default/tags.conf
@@ -1,3 +1,2 @@
 [sourcetype=heroku:router]
 web = enabled
-proxy = enabled

--- a/app/default/transforms.conf
+++ b/app/default/transforms.conf
@@ -4,6 +4,12 @@ REGEX = router\s-\s.+path="[^"]*\/__[^\/"]*"\s.+status=200
 DEST_KEY = queue
 FORMAT = nullQueue
 
+# Drop events for any canary double underscore (__) path.
+[heroku_router_canary_null_queue]
+REGEX = router\s-\s.+path="[^"]*\/__[^\/"]*"\shost=[\w\-]+-canary\.
+DEST_KEY = queue
+FORMAT = nullQueue
+
 # Various types of log messages for Heroku log drains. See https://devcenter.heroku.com/articles/logging#runtime-logs for more information.
 [heroku_app_source_type]
 REGEX = ^(\S+\sapp\s(?!api)|(\{.+\}))


### PR DESCRIPTION
Adds a new null queue transform to drop all double underscore requests to canary apps (which produce a lot of `/__gtg` request messages with an unsuccessful status code when they are scaled to 0 dynos).