### PR TITLE
Send Heroku runtime metric logs to the Splunk null queue

### DIFF
--- a/app/default/props.conf
+++ b/app/default/props.conf
@@ -17,7 +17,7 @@ SEDCMD-strip_json_prefix = s/^.+\s-\s(\{.+\})\s*$/\1/
 TRANSFORMS-source_type = heroku_app_source_type, heroku_system_source_type, heroku_router_source_type, heroku_api_source_type
 
 # Do not index some high volume low value messages.
-TRANSFORMS-heroku_router_null_queue = heroku_router_double_underscore_null_queue, heroku_router_canary_null_queue
+TRANSFORMS-heroku_router_null_queue = heroku_router_double_underscore_null_queue, heroku_router_canary_null_queue, heroku_system_runtime_metrics_null_queue
 
 [heroku:app]
 category = Structured

--- a/app/default/transforms.conf
+++ b/app/default/transforms.conf
@@ -10,6 +10,12 @@ REGEX = router\s-\s.+path="[^"]*\/__[^\/"]*"\shost=[\w\-]+-canary\.
 DEST_KEY = queue
 FORMAT = nullQueue
 
+# Drop events that match the Heroku runtime metrics format
+[heroku_system_runtime_metrics_null_queue]
+REGEX = heroku\s\w+\.\d+\s-\ssource=\w+\.\d+\sdyno=heroku\.
+DEST_KEY = queue
+FORMAT = nullQueue
+
 # Various types of log messages for Heroku log drains. See https://devcenter.heroku.com/articles/logging#runtime-logs for more information.
 [heroku_app_source_type]
 REGEX = ^(\S+\sapp\s(?!api)|(\{.+\}))


### PR DESCRIPTION
Drop these log messages as metrics are better suited to be saved in a time series database rather than in Splunk.

With the increased adoption of Heroku log drains this should minimise any increased ingest license usage.

See https://devcenter.heroku.com/articles/log-runtime-metrics for more information on these log messages.

**Regex101 screenshot**

<img width="1931" alt="image" src="https://user-images.githubusercontent.com/51677/185176911-6d0dad5d-bdf0-4421-8ffe-48588aaa3a90.png">

Closes #20 (though we're not adding a new source type).