### PR TITLE
Add a `splunk_log_drain` Terraform module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "terraform"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,3 +55,18 @@ jobs:
 
       - name: Run slim validate
         run: slim validate splunk_heroku-latest.tar.gz
+
+  terraform:
+    name: Terraform Validate
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: terraform/examples/splunk_log_drain/
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: hashicorp/setup-terraform@v2
+
+      - run: terraform init
+
+      - run: terraform validate

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,34 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/terraform/examples/splunk_log_drain/.terraform.lock.hcl
+++ b/terraform/examples/splunk_log_drain/.terraform.lock.hcl
@@ -1,0 +1,46 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.3.2"
+  constraints = "~> 3.3.2"
+  hashes = [
+    "h1:YChjos7Hrvr2KgTc9GzQ+de/QE2VLAeRJgxFemnCltU=",
+    "zh:038293aebfede983e45ee55c328e3fde82ae2e5719c9bd233c324cfacc437f9c",
+    "zh:07eaeab03a723d83ac1cc218f3a59fceb7bbf301b38e89a26807d1c93c81cef8",
+    "zh:427611a4ce9d856b1c73bea986d841a969e4c2799c8ac7c18798d0cc42b78d32",
+    "zh:49718d2da653c06a70ba81fd055e2b99dfd52dcb86820a6aeea620df22cd3b30",
+    "zh:5574828d90b19ab762604c6306337e6cd430e65868e13ef6ddb4e25ddb9ad4c0",
+    "zh:7222e16f7833199dabf1bc5401c56d708ec052b2a5870988bc89ff85b68a5388",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b1b2d7d934784d2aee98b0f8f07a8ccfc0410de63493ae2bf2222c165becf938",
+    "zh:b8f85b6a20bd264fcd0814866f415f0a368d1123cd7879c8ebbf905d370babc8",
+    "zh:c3813133acc02bbebddf046d9942e8ba5c35fc99191e3eb057957dafc2929912",
+    "zh:e7a41dbc919d1de800689a81c240c27eec6b9395564630764ebb323ea82ac8a9",
+    "zh:ee6d23208449a8eaa6c4f203e33f5176fa795b4b9ecf32903dffe6e2574732c2",
+  ]
+}
+
+provider "registry.terraform.io/heroku/heroku" {
+  version     = "5.1.2"
+  constraints = "~> 5.1.2"
+  hashes = [
+    "h1:pjf0KADkGu7Nea5xPwKqKCGim+WxX9uQMXnwEhj18ZI=",
+    "zh:0a1dfe80eda8bd1621ebbbcf33cb475cfd20c685eaa0d23f1652d7d3c0f69b81",
+    "zh:1cadc7aa73579f50bd32e222f93a486b9fdc8e2fab7be7fcb92fb31ff217358d",
+    "zh:2cd692fd2a563b685fa91e29435351f6c8fe3f389a8482a1755c3d4f7a09809c",
+    "zh:41d8fc28e59e36870fc66767cbc271b2209e85714ad934ac271402ef26a30791",
+    "zh:67775fdc050dea3b191fd74a3be7a2857de70ef4690bf75b960e7c2bbb0ffe8d",
+    "zh:67f204d5c845e4fe5f94b51998f7be72bdb85cbb8e40b7d5bd799d6e74826a81",
+    "zh:7ec05e2eb1aed844b8c9c5151bc8012f546de14c16579f42735a12efe1db7e7d",
+    "zh:8d70482573d44fa553594d4262df96e6565b31ff5eae8267d93a7ee9c9052fab",
+    "zh:a8d445c9204b08f60682a134b5b76b3641634ed50c06eb4f6b38a7eb7c4026dc",
+    "zh:c00c0f220bfc1112a27fd028119249acacd814b6c964ed6ed14bbfe24e004ee7",
+    "zh:d0327c73e46fdfea9ae626cf057940af0ffa49bf16a492a3acced60aa9789526",
+    "zh:d540a68e1bed9bcb8ab1d56de43ff3afc60f9ea186d37bdcd2a60eb272d246e2",
+    "zh:df2065ca1a7b42f69080f3db8b4bbfaaacda7e4765a001ab2636e8883f72c535",
+    "zh:df8433d56b1944b63e0285943d54e3fbed5bfa52fd8314cd6cf4856f8f5de038",
+    "zh:fd50c1fd24007462ffeb75fdc04e046935f2b6dff35b678ebda14f16e9a7bc87",
+    "zh:fd9d4360276cda61f6d059ef66f8615280100f6e9601f5c5ff269b41c85d8440",
+  ]
+}

--- a/terraform/examples/splunk_log_drain/main.tf
+++ b/terraform/examples/splunk_log_drain/main.tf
@@ -1,0 +1,7 @@
+module "splunk_log_drain" {
+  source              = "../../modules/splunk_log_drain"
+  heroku_app_name     = "example"
+  splunk_host         = "http-inputs-example.splunkcloud.com"
+  splunk_event_source = "example"
+  splunk_hec_token    = "123e4567-e89b-12d3-a456-426614174000"
+}

--- a/terraform/modules/splunk_log_drain/README.md
+++ b/terraform/modules/splunk_log_drain/README.md
@@ -7,12 +7,14 @@ Configure a Heroku log drain for Splunk using Terraform. Creates a [`heroku_drai
 ```tf
 module "splunk_log_drain" {
   source = "github.com/Financial-Times/splunk-heroku//terraform/modules/splunk_log_drain"
-  splunk_source = "example"
-  splunk_hec_token = "123e4567-e89b-12d3-a456-426614174000"
+  heroku_app_name     = "example"
+  splunk_host         = "http-inputs-example.splunkcloud.com"
+  splunk_event_source = "example"
+  splunk_hec_token    = "123e4567-e89b-12d3-a456-426614174000"
 }
 ```
 
-### Importing
+## Importing
 
 When importing a Splunk Heroku log drain resource, the ID must be built using the app name colon the unique ID from the Heroku API. For an app named `example` with a log drain ID of `123e4567-e89b-12d3-a456-426614174000` and the url attribute value defined for the resource, you would import it as:
 

--- a/terraform/modules/splunk_log_drain/README.md
+++ b/terraform/modules/splunk_log_drain/README.md
@@ -1,0 +1,23 @@
+# Splunk Log Drain
+
+Configure a Heroku log drain for Splunk using Terraform. Creates a [`heroku_drain` resource](https://registry.terraform.io/providers/heroku/heroku/latest/docs/resources/drain).
+
+## Example usage
+
+```tf
+module "splunk_log_drain" {
+  source = "github.com/Financial-Times/splunk-heroku//terraform/modules/splunk_log_drain"
+  splunk_source = "example"
+  splunk_hec_token = "123e4567-e89b-12d3-a456-426614174000"
+}
+```
+
+### Importing
+
+When importing a Splunk Heroku log drain resource, the ID must be built using the app name colon the unique ID from the Heroku API. For an app named `example` with a log drain ID of `123e4567-e89b-12d3-a456-426614174000` and the url attribute value defined for the resource, you would import it as:
+
+```sh
+$ terraform import module.splunk_log_drain.heroku_drain.splunk_log_drain example:123e4567-e89b-12d3-a456-426614174000
+```
+
+Use [`heroku drains`](https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-drains) to list the existing log drains of an app.

--- a/terraform/modules/splunk_log_drain/main.tf
+++ b/terraform/modules/splunk_log_drain/main.tf
@@ -27,6 +27,6 @@ resource "random_uuid" "splunk_hec_channel" {}
 #
 # See https://docs.splunk.com/Documentation/Splunk/9.0.0/Data/HECExamples#Example_4:_Send_multiple_raw_text_events_to_HEC for more information on the supported URL parameters.
 resource "heroku_drain" "splunk_log_drain" {
-  app_id        = heroku_app.app.id
-  sensitive_url = "https://x:${var.splunk_hec_token}@${var.splunk_host}/services/collector/raw/1.0?%{ if var.source }source=${urlencode(var.source)}&%{ endif }host=${urlencode(heroku_app.app.heroku_hostname)}&channel=${random_uuid.splunk_hec_channel.id}"
+  app_id        = data.heroku_app.app
+  sensitive_url = "https://x:${var.splunk_hec_token}@${var.splunk_host}/services/collector/raw/1.0?%{ if var.splunk_event_source }source=${urlencode(var.splunk_event_source)}&%{ endif }host=${urlencode(data.heroku_app.app.heroku_hostname)}&channel=${random_uuid.splunk_hec_channel.id}"
 }

--- a/terraform/modules/splunk_log_drain/main.tf
+++ b/terraform/modules/splunk_log_drain/main.tf
@@ -1,13 +1,14 @@
 terraform {
+  required_version = "~> 1.2"
+
   required_providers {
     heroku = {
       source  = "heroku/heroku"
-      version = "~> 5.1.2"
+      version = "~> 5.1"
     }
-
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.3.2"
+      version = "~> 3.3"
     }
   }
 }
@@ -28,5 +29,5 @@ resource "random_uuid" "splunk_hec_channel" {}
 # See https://docs.splunk.com/Documentation/Splunk/9.0.0/Data/HECExamples#Example_4:_Send_multiple_raw_text_events_to_HEC for more information on the supported URL parameters.
 resource "heroku_drain" "splunk_log_drain" {
   app_id        = data.heroku_app.app
-  sensitive_url = "https://x:${var.splunk_hec_token}@${var.splunk_host}/services/collector/raw/1.0?%{ if can(var.splunk_event_source) }source=${urlencode(var.splunk_event_source)}&%{ endif }host=${urlencode(data.heroku_app.app.heroku_hostname)}&channel=${random_uuid.splunk_hec_channel.id}"
+  sensitive_url = "https://x:${var.splunk_hec_token}@${var.splunk_host}/services/collector/raw/1.0?%{if can(var.splunk_event_source)}source=${urlencode(var.splunk_event_source)}&%{endif}host=${urlencode(data.heroku_app.app.heroku_hostname)}&channel=${random_uuid.splunk_hec_channel.id}"
 }

--- a/terraform/modules/splunk_log_drain/main.tf
+++ b/terraform/modules/splunk_log_drain/main.tf
@@ -28,5 +28,5 @@ resource "random_uuid" "splunk_hec_channel" {}
 # See https://docs.splunk.com/Documentation/Splunk/9.0.0/Data/HECExamples#Example_4:_Send_multiple_raw_text_events_to_HEC for more information on the supported URL parameters.
 resource "heroku_drain" "splunk_log_drain" {
   app_id        = data.heroku_app.app
-  sensitive_url = "https://x:${var.splunk_hec_token}@${var.splunk_host}/services/collector/raw/1.0?%{ if var.splunk_event_source }source=${urlencode(var.splunk_event_source)}&%{ endif }host=${urlencode(data.heroku_app.app.heroku_hostname)}&channel=${random_uuid.splunk_hec_channel.id}"
+  sensitive_url = "https://x:${var.splunk_hec_token}@${var.splunk_host}/services/collector/raw/1.0?%{ if can(var.splunk_event_source) }source=${urlencode(var.splunk_event_source)}&%{ endif }host=${urlencode(data.heroku_app.app.heroku_hostname)}&channel=${random_uuid.splunk_hec_channel.id}"
 }

--- a/terraform/modules/splunk_log_drain/main.tf
+++ b/terraform/modules/splunk_log_drain/main.tf
@@ -1,0 +1,35 @@
+terraform {
+  required_providers {
+    heroku = {
+      source  = "heroku/heroku"
+      version = "~> 5.1.2"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.3.2"
+    }
+  }
+}
+
+provider "heroku" {}
+provider "random" {}
+
+# Get the Heroku app ID and hostname from it's unique name.
+data "heroku_app" "app" {
+  name = var.heroku_app_name
+}
+
+# Generate a random UUID for use as the value of the `channel` URL parameter.
+# See https://docs.splunk.com/Documentation/Splunk/9.0.0/Data/FormateventsforHTTPEventCollector#Channel_identifier_header for more information.
+resource "random_uuid" "splunk_hec_channel" {}
+
+# Configure the log drain resource.
+#
+# Uses basic authentication to avoid passing the Splunk HEC token as a URL parameter.
+#
+# See https://docs.splunk.com/Documentation/Splunk/9.0.0/Data/HECExamples#Example_4:_Send_multiple_raw_text_events_to_HEC for more information on the supported URL parameters.
+resource "heroku_drain" "splunk_log_drain" {
+  app_id        = heroku_app.app.id
+  sensitive_url = "https://x:${var.splunk_hec_token}@${var.splunk_host}/services/collector/raw/1.0?%{ if var.source }source=${urlencode(var.source)}&%{ endif }host=${urlencode(heroku_app.app.heroku_hostname)}&channel=${random_uuid.splunk_hec_channel.id}"
+}

--- a/terraform/modules/splunk_log_drain/main.tf
+++ b/terraform/modules/splunk_log_drain/main.tf
@@ -12,9 +12,6 @@ terraform {
   }
 }
 
-provider "heroku" {}
-provider "random" {}
-
 # Get the Heroku app ID and hostname from it's unique name.
 data "heroku_app" "app" {
   name = var.heroku_app_name

--- a/terraform/modules/splunk_log_drain/outputs.tf
+++ b/terraform/modules/splunk_log_drain/outputs.tf
@@ -1,0 +1,6 @@
+# Output the same values as a heroku_drain resource.
+# See https://registry.terraform.io/providers/heroku/heroku/latest/docs/resources/drain#attributes-reference for more information.
+output "token" {
+  value = heroku_drain.splunk_log_drain.token
+  description = "The unique token for your created drain."
+}

--- a/terraform/modules/splunk_log_drain/variables.tf
+++ b/terraform/modules/splunk_log_drain/variables.tf
@@ -4,7 +4,13 @@ variable "heroku_app_name" {
   nullable = false
 }
 
-variable "splunk_source" {
+variable "splunk_host" {
+  type = string
+  description = "The Splunk HTTP Event Collector host, e.g. http-inputs-example.splunkcloud.com or input-example.cloud.splunk.com:8089."
+  nullable = false
+}
+
+variable "splunk_event_source" {
   type = string
   description = "The value to use as the `source` field in events."
 }

--- a/terraform/modules/splunk_log_drain/variables.tf
+++ b/terraform/modules/splunk_log_drain/variables.tf
@@ -1,0 +1,17 @@
+variable "heroku_app_name" {
+  type = string
+  description = "The name of the application. In Heroku, this is also the unique ID."
+  nullable = false
+}
+
+variable "splunk_source" {
+  type = string
+  description = "The value to use as the `source` field in events."
+}
+
+variable "splunk_hec_token" {
+  type = string
+  description = "The Splunk HTTP Event Collector (HEC) token to use."
+  sensitive = true
+  nullable = false
+}


### PR DESCRIPTION
Trying out creating a Terraform module.

I've not managed to test this but thought it'd be interesting to get some reusable configuration out there for teams to use if they have adopted Terraform.

The configuration has been verified using `terraform validate` in `terraform/examples/splunk_log_drain/`.

Resolves https://github.com/Financial-Times/splunk-heroku/issues/51.