### PR TITLE
Add `heroku:router` event types for errors and warnings

### DIFF
--- a/app/default/app.conf
+++ b/app/default/app.conf
@@ -15,4 +15,3 @@ version = 2.3.0
 
 [package]
 check_for_updates = false
-

--- a/app/default/eventtypes.conf
+++ b/app/default/eventtypes.conf
@@ -1,0 +1,7 @@
+[heroku_router_error]
+search = sourcetype=heroku:router at=error
+color = et_red
+
+[heroku_router_warning]
+search = sourcetype=heroku:router at=warning
+color = et_yellow

--- a/app/metadata/default.meta
+++ b/app/metadata/default.meta
@@ -3,6 +3,9 @@
 []
 access = read : [ * ], write : [ sc_admin, admin, power ]
 
+[eventypes]
+export = system
+
 [fields]
 export = system
 

--- a/app/metadata/default.meta
+++ b/app/metadata/default.meta
@@ -1,9 +1,9 @@
 # Application-level permissions
 
 []
-access = read : [ * ], write : [ sc_admin, admin, power ]
+access = read : [ * ], write : [ sc_admin, admin ]
 
-[eventypes]
+[eventtypes]
 export = system
 
 [fields]


### PR DESCRIPTION
Use event types to highlight using colour error and warning messages.

- [x] Fix the event type permissions so that they are Global rather than App

There is a priority conflict with the Splunk build-in event type called `err0r`, which also has the default priority of `1`, but no value for `color`. To get this working for Heroku router errors we would need to manually set the priority to `2` for the `err0r` event type in Splunk.

Adding/editing a Splunk app `eventype.conf` file will require a restart of Splunk.

<img width="2032" alt="Screenshot 2022-08-26 at 15 01 44" src="https://user-images.githubusercontent.com/51677/186922684-8ca3b000-7b6b-4612-8d25-7b34d11868f2.png">

Resolves #48.