### PR TITLE
Match on start of a JSON message

### DIFF
--- a/app/default/transforms.conf
+++ b/app/default/transforms.conf
@@ -18,7 +18,7 @@ FORMAT = nullQueue
 
 # Various types of log messages for Heroku log drains. See https://devcenter.heroku.com/articles/logging#runtime-logs for more information.
 [heroku_app_source_type]
-REGEX = ^(\S+\sapp\s(?!api)|(\{.+\}))
+REGEX = ^(\S+\sapp\s(?!api)|(\{.+\:))
 FORMAT = sourcetype::heroku:app
 DEST_KEY = MetaData:Sourcetype
 WRITE_META = true


### PR DESCRIPTION
Splunk by default only passes the first 4,096 characters of an event to the regex in a transform.

Resolves https://github.com/Financial-Times/splunk-heroku/issues/56.