### PR TITLE
Extract the `status` router field explicitly

### DIFF
--- a/app/default/props.conf
+++ b/app/default/props.conf
@@ -45,7 +45,7 @@ EXTRACT-component = ^\S+\s(?<component>\S+)
 # We convert `fwd` into a multivalue field using `fields.conf`.
 
 # Splunk CIM fields for the web model, see https://docs.splunk.com/Documentation/CIM/5.0.1/User/Web and https://devcenter.heroku.com/articles/http-routing#info-logs.
-# The `status` field already exists in the log message.
+EXTRACT-status = status=(?<status>\d{3})\s
 EXTRACT-duration = service=(?<duration>\d+)ms
 EXTRACT-uri_path = path="(?<uri_path>[^#?"]+)\S*"
 EXTRACT-uri_query = path="\S+(?<uri_query>\?[^"]+)"


### PR DESCRIPTION
When Splunk automatically extracts fields for a request such as:

```
2022-10-13T16:03:35.462875+00:00 heroku router - at=info method=GET path="/wp-admin/admin.php?page=download_report&report=users&status=all" host=.herokuapp.com request_id=f752fa8cd050cfd13d624b24c121a26c33cdeb62ccbe028ff0266c89ce346e85 fwd="10.0.0.0" dyno=web.4 connect=0ms service=2ms status=404 bytes=440 protocol=http
```

It currently extracts the `path` field, and also `page`, `report` and `status` as fields out of the value. For `status` this is unexpected as there's another field later on in the message that's more important for us to extract.

Being explicit about extracting the `status` field resolves the problem.

Tested locally, this will still have other fields extracted out of the value of the `path` field, but not status and any others that we're explicit about.

